### PR TITLE
Add Set Default Value action to local schedules

### DIFF
--- a/dslink.json
+++ b/dslink.json
@@ -1,6 +1,6 @@
 {
   "name": "dslink-dart-schedule",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Schedule DSLink",
   "main": "bin/run.dart",
   "engines": {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,7 +49,8 @@ main(List<String> args) async {
         (String path) => new FetchSpecialEventsNode(path),
     RemoveSpecialEventNode.isType:
         (String path) => new RemoveSpecialEventNode(path, link),
-    TimezoneNode.isType: (String path) => new TimezoneNode(path, link)
+    TimezoneNode.isType: (String path) => new TimezoneNode(path, link),
+    SetDefaultNode.isType: (String path) => new SetDefaultNode(path, link)
   },
       defaultNodes: {
         AddICalRemoteScheduleNode.pathName: AddICalRemoteScheduleNode.def(),

--- a/lib/src/nodes/local_schedules.dart
+++ b/lib/src/nodes/local_schedules.dart
@@ -451,6 +451,8 @@ class ICalendarLocalSchedule extends SimpleNode {
       if (untilTimer != null && untilTimer.isActive) untilTimer.cancel();
 
       var setNextEvent = (ValueAtTime v) {
+        // Could fire before nodes are initialized on startup.
+        if (provider == null) return;
         provider.updateValue("${path}/$_current", v.value);
         next = state.getNext();
         if (next != null) {

--- a/lib/src/nodes/local_schedules.dart
+++ b/lib/src/nodes/local_schedules.dart
@@ -97,7 +97,8 @@ class ICalendarLocalSchedule extends SimpleNode {
           AddLocalEventNode.pathName: AddLocalEventNode.def(),
           AddSpecialEventNode.pathName: AddSpecialEventNode.def(),
           FetchSpecialEventsNode.pathName: FetchSpecialEventsNode.def(),
-          RemoveSpecialEventNode.pathName: RemoveSpecialEventNode.def()
+          RemoveSpecialEventNode.pathName: RemoveSpecialEventNode.def(),
+          SetDefaultNode.pathName: SetDefaultNode.def()
         },
         FetchEventsNode.pathName: FetchEventsNode.def()
       };
@@ -305,6 +306,7 @@ class ICalendarLocalSchedule extends SimpleNode {
     _addMissing('$path/$_remove',
         {r"$name": "Remove", r"$invokable": "write", r"$is": _remove});
     _addMissing('$path/${FetchEventsNode.pathName}', FetchEventsNode.def());
+    _addMissing('$path/${SetDefaultNode.pathName}', SetDefaultNode.def());
     _addMissing('$path/$_events', {
       r"$name": "Events",
       AddLocalEventNode.pathName: AddLocalEventNode.def(),
@@ -575,6 +577,37 @@ class ICalendarLocalSchedule extends SimpleNode {
   String calculateTag() {
     var json = const JsonEncoder().convert(storedEvents);
     return sha256.convert(const Utf8Encoder().convert(json)).toString();
+  }
+}
+
+class SetDefaultNode extends SimpleNode {
+  static const String isType = 'setDefaultValue';
+  static const String pathName = 'Set_Default';
+
+  static const String _value = 'Value';
+  static const String _default = '@defaultValue';
+
+  static Map<String, dynamic> def() => {
+    r'$is': isType,
+    r'$name': 'Set Default Value',
+    r'$params': [{'name': _value, 'type':'dynamic', 'placeholder': 'value'}],
+    r'$invokable': 'write'
+  };
+
+  final LinkProvider _link;
+
+  SetDefaultNode(String path, this._link) : super(path);
+
+  Future onInvoke(Map<String, dynamic> params) async {
+    var p = parent as ICalendarLocalSchedule;
+
+    // Can't just updateValue on an attribute. And can't rely on onSetAttribute
+    // being triggered, as most attributes are stored at Broker and not DSLink
+    // level, the link doesn't get the updated value.
+    p.attributes[_default] = params[_value];
+    p.updateList(_default);
+    await p.loadSchedule();
+    _link.save();
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dslink_schedule
-version: 0.0.9
+version: 0.0.10
 description: Schedule DSLink
 dependencies:
   dslink:


### PR DESCRIPTION
Calling @set on an attribute only updated to the broker, not to
DSLink itself. As such when it was changed, the DSLink continued to
refer to the original value stored. This action updates the local
value of the attribute, and pushes an updateList to broker